### PR TITLE
Initial SLA configuration for Mars 2

### DIFF
--- a/Elegoo.ini
+++ b/Elegoo.ini
@@ -524,3 +524,33 @@ bed_shape = 0x0,210x0,210x210,0x210
 max_print_height = 200
 printer_model = NEPTUNE1
 printer_notes = Do not remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_ELEGOO\nPRINTER_MODEL_NEPTUNE2D\nPRINTER_HAS_BOWDEN
+
+[printer_model:MARS 2 PRO]
+name = Elegoo Mars 2 Pro
+variants = default
+technology = SLA
+family = MARS 2
+default_materials = Generic Blue Resin @MONO 0.05
+
+[sla_material:*common ELEGOO SLA*]
+compatible_printers_condition = printer_notes=~/.*VENDOR_ELEGOO.*/ and printer_notes=~/.*SLA.*/ 
+compatible_prints_condition = layer_height == 0.05
+exposure_time = 7
+initial_exposure_time = 40
+initial_layer_height = 0.05
+material_correction = 1,1,1
+material_notes = #Distances are defined in mm, speeds are defined in mm/s.\n#Delay is defined in s.\nLIFT_DISTANCE=8.0\nLIFT_SPEED=2.5\nRETRACT_SPEED=3.0\nBOTTOM_LIFT_SPEED=2.0\nBOTTOM_LIFT_DISTANCE=9.0\nDELAY_BEFORE_EXPOSURE=0.5\nANTIALIASING=1
+
+[sla_material:*common 0.05 ELEGOO SLA*]
+inherits = *common ELEGOO SLA*
+
+[sla_material:Generic Blue Resin @MONO 0.05]
+inherits = *common 0.05 ELEGOO SLA*
+exposure_time = 2.5
+initial_exposure_time = 40
+material_type = Tough
+material_vendor = Generic
+material_colour = #6080EC
+compatible_printers_condition = printer_notes=~/.*MARS.*/ and printer_notes=~/.*VENDOR_ELEGOO.*/ and printer_notes=~/.*SLA.*/ 
+
+


### PR DESCRIPTION
An initial crack at adding an SLA configuration for the Mars 2 based on entries from anycubic.